### PR TITLE
Add support for 24 hour mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,18 @@
 cmake_minimum_required(VERSION 3.21)
 project(lcd-tools VERSION 0.1)
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+
 set(CMAKE_CXX_STANDARD 20)
 
 find_package(PkgConfig REQUIRED)
 find_package(CLI11 REQUIRED)
-pkg_search_module(LIBHYBRIS REQUIRED hybris-egl-platform)
+find_package(Mlite5 MODULE REQUIRED)
+find_package(Qt5 COMPONENTS Core REQUIRED)
+pkg_check_modules(LIBHYBRIS REQUIRED hybris-egl-platform libandroid-properties)
 
 add_subdirectory(src)
 
 install(TARGETS lcd-tools DESTINATION bin)
 install(FILES systemd/lcd-sync-time.service systemd/lcd-sync-time.timer
-		DESTINATION /etc/systemd/system)
+		DESTINATION /usr/lib/systemd/user)

--- a/cmake/FindMlite5.cmake
+++ b/cmake/FindMlite5.cmake
@@ -1,0 +1,40 @@
+# Try to find mlite5
+# Once done this will define
+# MLITE5_FOUND - System has mlite5
+# MLITE5_INCLUDE_DIRS - The mlite5 include directories
+# MLITE5_LIBRARIES - The libraries needed to use mlite5
+# MLITE5_DEFINITIONS - Compiler switches required for using mlite5
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_Mlite5 QUIET mlite5)
+set(Mlite5_DEFINITIONS ${PC_Mlite5_CFLAGS_OTHER})
+
+find_path(Mlite5_INCLUDE_DIRS
+	NAMES mlite-global.h
+	PATH_SUFFIXES mlite5
+	PATHS ${PC_Mlite5_INCLUDEDIR} ${PC_Mlite5_INCLUDE_DIRS})
+
+find_library(Mlite5_LIBRARIES
+	NAMES mlite5
+	PATHS ${PC_Mlite5_LIBDIR} ${PC_Mlite5_LIBRARY_DIRS})
+
+set(Mlite5_VERSION ${PC_Mlite5_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Mlite5
+	FOUND_VAR
+		Mlite5_FOUND
+	REQUIRED_VARS
+		Mlite5_LIBRARIES
+		Mlite5_INCLUDE_DIRS
+	VERSION_VAR
+		Mlite5_VERSION)
+
+mark_as_advanced(Mlite5_INCLUDE_DIR Mlite5_LIBRARY Mlite5_VERSION)
+
+if(Mlite5_FOUND AND NOT TARGET Mlite5::Mlite5)
+	add_library(Mlite5::Mlite5 UNKNOWN IMPORTED)
+	set_target_properties(Mlite5::Mlite5 PROPERTIES
+		IMPORTED_LOCATION "${Mlite5_LIBRARIES}"
+		INTERFACE_INCLUDE_DIRECTORIES "${Mlite5_INCLUDE_DIRS}")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(lcd-tools lcd-tools.cpp lcd-sync-time.cpp)
-target_link_libraries(lcd-tools PUBLIC CLI11::CLI11 ${LIBHYBRIS_LIBRARIES})
+target_link_libraries(lcd-tools PUBLIC CLI11::CLI11 Mlite5::Mlite5 Qt::Core ${LIBHYBRIS_LIBRARIES})

--- a/src/lcd-sync-time.cpp
+++ b/src/lcd-sync-time.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <dlfcn.h>
 #include <hybris/common/dlfcn.h>
+#include <hybris/properties/properties.h>
+#include <MGConfItem>
 
 int AsteroidOS::LCD_Tools::SyncTime() {
 	auto lib_mcutool = hybris_dlopen("libmcutool.so", RTLD_LAZY);
@@ -10,6 +12,15 @@ int AsteroidOS::LCD_Tools::SyncTime() {
 		std::cerr << "Unable to load libmcutool.so" << std::endl;
 		return -1;
 	}
+
+	auto use12h = new MGConfItem("/org/asteroidos/settings/use-12h-format");
+
+	if (use12h->value(false).toBool()) {
+		property_set("persist.sys.time_12_24", "12");
+	} else {
+		property_set("persist.sys.time_12_24", "24");
+	}
+
 	auto syncTime = (int (*)())
 			hybris_dlsym(lib_mcutool, "Java_com_mobvoi_ticwear_mcuservice_CoreService_nativeSyncTime");
 	if (!syncTime) {


### PR DESCRIPTION
This adds support for 12/24 hour mode switching.
AsteroidOS uses/sets a DConf value to enable and detect 12 hour mode.
This is stored under the user settings, so make this daemon run under the user session instead of root.
mlite is used to read the DConf value.
Then use the Android `property_set()` function defined by libhybris to change the expected property in `libmcutool.so`.


This should at least partially fix https://github.com/AsteroidOS/meta-smartwatch/issues/94. There's one more issue remaining: The 12/24 hour mode doesn't change when you change the unit, you need to update the time to trigger the `lcd-tools` service.
I'm not sure how we would tackle this issue.