### PR TITLE
Add support for  koi's secondary LCD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(lcd-tools lcd-tools.cpp lcd-sync-time.cpp)
+add_executable(lcd-tools lcd-tools.cpp catfish-tools.cpp koi-tools.cpp)
 target_link_libraries(lcd-tools PUBLIC CLI11::CLI11 Mlite5::Mlite5 Qt::Core ${LIBHYBRIS_LIBRARIES})

--- a/src/catfish-tools.cpp
+++ b/src/catfish-tools.cpp
@@ -1,4 +1,4 @@
-#include "lcd-tools.h"
+#include "catfish-tools.h"
 
 #include <iostream>
 #include <dlfcn.h>
@@ -6,7 +6,7 @@
 #include <hybris/properties/properties.h>
 #include <MGConfItem>
 
-int AsteroidOS::LCD_Tools::SyncTime() {
+int AsteroidOS::LCD_Tools::CatfishSyncTime() {
 	auto lib_mcutool = hybris_dlopen("libmcutool.so", RTLD_LAZY);
 	if (!lib_mcutool) {
 		std::cerr << "Unable to load libmcutool.so" << std::endl;

--- a/src/catfish-tools.cpp
+++ b/src/catfish-tools.cpp
@@ -6,11 +6,12 @@
 #include <hybris/properties/properties.h>
 #include <MGConfItem>
 
-int AsteroidOS::LCD_Tools::CatfishSyncTime() {
+namespace AsteroidOS::LCD_Tools::Catfish {
+void SyncTime(int) {
 	auto lib_mcutool = hybris_dlopen("libmcutool.so", RTLD_LAZY);
 	if (!lib_mcutool) {
 		std::cerr << "Unable to load libmcutool.so" << std::endl;
-		return -1;
+		return;
 	}
 
 	auto use12h = new MGConfItem("/org/asteroidos/settings/use-12h-format");
@@ -26,12 +27,12 @@ int AsteroidOS::LCD_Tools::CatfishSyncTime() {
 	if (!syncTime) {
 		std::cerr << "Unable to get symbol" << std::endl;
 		hybris_dlclose(lib_mcutool);
-		return -1;
+		return;
 	}
 	auto res = syncTime();
 	if (hybris_dlclose(lib_mcutool)) {
 		std::cerr << "Failed to safely close the library" << std::endl;
-		return -1;
+		return;
 	}
-	return res;
+}
 }

--- a/src/catfish-tools.h
+++ b/src/catfish-tools.h
@@ -1,0 +1,7 @@
+#ifndef ASTEROIDOS_CATFISH_TOOLS_H
+#define ASTEROIDOS_CATFISH_TOOLS_H
+
+namespace AsteroidOS::LCD_Tools {
+	int CatfishSyncTime();
+}
+#endif //ASTEROIDOS_CATFISH_TOOLS_H

--- a/src/catfish-tools.h
+++ b/src/catfish-tools.h
@@ -1,7 +1,7 @@
 #ifndef ASTEROIDOS_CATFISH_TOOLS_H
 #define ASTEROIDOS_CATFISH_TOOLS_H
 
-namespace AsteroidOS::LCD_Tools {
-	int CatfishSyncTime();
+namespace AsteroidOS::LCD_Tools::Catfish {
+	void SyncTime(int);
 }
 #endif //ASTEROIDOS_CATFISH_TOOLS_H

--- a/src/koi-tools.cpp
+++ b/src/koi-tools.cpp
@@ -1,0 +1,38 @@
+#include "koi-tools.h"
+
+#include <iostream>
+#include <dlfcn.h>
+#include <MGConfItem>
+
+#include <QTime>
+#include <QDate>
+#include <QFile>
+
+int AsteroidOS::LCD_Tools::KoiSyncTime() {
+	char outputBuff[7] = {0xFE,0x01,0x01,0x00,0x00,0x00,0x00};
+	outputBuff[3] = (uint8_t) !MGConfItem("/org/asteroidos/settings/use-12h-format").value().toBool();
+	Write(outputBuff);
+
+	QDate dateNow = QDate::currentDate();
+	QTime timeNow = QTime::currentTime();
+	outputBuff[0] = (uint8_t) 0x50;
+	outputBuff[1] = (uint8_t) 0;
+	outputBuff[2] = (uint8_t)((((dateNow.year() - 2000) & 0xEF) << 1) | ((dateNow.month() & 0x08) >> 3));
+	outputBuff[3] = (uint8_t) ((dateNow.month() & 0x07) << 5) | ((dateNow.day() & 0x1F));
+	outputBuff[4] = (uint8_t) (((dateNow.dayOfWeek() & 0x07) << 5) |  (timeNow.hour() & 0x1F));
+	outputBuff[5] = (uint8_t) (timeNow.minute() & 0xFF);
+	outputBuff[6] = (uint8_t) ((timeNow.second() + 1) & 0xFF); //the original casio code seems to add one second here to compensate for an update delay in the subcpu
+	return Write(outputBuff);
+}
+
+int AsteroidOS::LCD_Tools::Write(char* data) {
+	QFile multiSensorFile("/dev/MultiSensors_CD_01");
+	if(!multiSensorFile.open(QIODevice::WriteOnly | QIODevice::Text))
+	{
+		qCritical("Unable to open file for write. Check permissions");
+		return(-1);
+    }
+	multiSensorFile.write(data,7);
+	multiSensorFile.close();
+	return 1;
+}

--- a/src/koi-tools.cpp
+++ b/src/koi-tools.cpp
@@ -1,5 +1,6 @@
 #include "koi-tools.h"
 
+#include <array>
 #include <iostream>
 #include <dlfcn.h>
 #include <MGConfItem>
@@ -8,42 +9,45 @@
 #include <QDate>
 #include <QFile>
 
-int AsteroidOS::LCD_Tools::KoiSyncTime() {
-	char outputBuff[7] = {0xFE,0x01,0x01,0x00,0x00,0x00,0x00};
-	outputBuff[3] = (uint8_t) !MGConfItem("/org/asteroidos/settings/use-12h-format").value().toBool();
-	Write(outputBuff);
+using SpiMsg = std::array<uint8_t, 7>;
 
-	QDate dateNow = QDate::currentDate();
-	QTime timeNow = QTime::currentTime();
-	outputBuff[0] = (uint8_t) 0x50;
-	outputBuff[1] = (uint8_t) 0;
-	outputBuff[2] = (uint8_t)((((dateNow.year() - 2000) & 0xEF) << 1) | ((dateNow.month() & 0x08) >> 3));
-	outputBuff[3] = (uint8_t) ((dateNow.month() & 0x07) << 5) | ((dateNow.day() & 0x1F));
-	outputBuff[4] = (uint8_t) (((dateNow.dayOfWeek() & 0x07) << 5) |  (timeNow.hour() & 0x1F));
-	outputBuff[5] = (uint8_t) (timeNow.minute() & 0xFF);
-	outputBuff[6] = (uint8_t) ((timeNow.second() + 1) & 0xFF); //the original casio code seems to add one second here to compensate for an update delay in the subcpu
-	return Write(outputBuff);
-}
-
-int AsteroidOS::LCD_Tools::KoiSetDisplayColor(bool value) {
-	char outputBuff[7] = {0xFE,0x01,0x05,0x00,0x00,0x00,0x00};
-	outputBuff[3] = (uint8_t) value;
-	return Write(outputBuff);
-}
-
-int AsteroidOS::LCD_Tools::KoiPrepareTimepiece() {
-	char outputBuff[7] = {0x02,0xC1,0xBE,0x78,0x3F,0x91,0xC7};
-	return Write(outputBuff);
-}
-
-int AsteroidOS::LCD_Tools::Write(char* data) {
+static void Write(const SpiMsg& data) {
 	QFile multiSensorFile("/dev/MultiSensors_CD_01");
 	if(!multiSensorFile.open(QIODevice::WriteOnly | QIODevice::Text))
 	{
 		qCritical("Unable to open file for write. Check permissions");
-		return(-1);
-    }
-	multiSensorFile.write(data,7);
+		return;
+	}
+	multiSensorFile.write((const char *)data.data(), data.size());
 	multiSensorFile.close();
-	return 1;
 }
+
+static void KoiSet12H(bool value) {
+	Write({0xFE,0x01,0x01,value,0x00,0x00,0x00});
+}
+
+namespace AsteroidOS::LCD_Tools::Koi {
+
+void SyncTime(int) {
+	KoiSet12H(!MGConfItem("/org/asteroidos/settings/use-12h-format").value().toBool());
+	QDate dateNow = QDate::currentDate();
+	QTime timeNow = QTime::currentTime();
+	Write({
+	(uint8_t) 0x50,
+	(uint8_t) 0,
+	(uint8_t) ((((dateNow.year() - 2000) & 0xEF) << 1) | ((dateNow.month() & 0x08) >> 3)),
+	(uint8_t) ((dateNow.month() << 5) | (dateNow.day() & 0x1F)),
+	(uint8_t) ((dateNow.dayOfWeek() << 5) | (timeNow.hour() & 0x1F)),
+	(uint8_t) (timeNow.minute() & 0xFF),
+	(uint8_t) ((timeNow.second() + 1) & 0xFF) //the original casio code seems to add one second here to compensate for an update delay in the subcpu
+	});
+}
+
+void SetDisplayColor(bool value) {
+	Write({0xFE,0x01,0x05,value,0x00,0x00,0x00});
+}
+
+void PrepareTimepiece(int) {
+	Write({0x02,0xC1,0xBE,0x78,0x3F,0x91,0xC7});
+}
+} // end of namespace AsteroidOS::LCD_Tools::Koi

--- a/src/koi-tools.cpp
+++ b/src/koi-tools.cpp
@@ -25,6 +25,12 @@ int AsteroidOS::LCD_Tools::KoiSyncTime() {
 	return Write(outputBuff);
 }
 
+int AsteroidOS::LCD_Tools::KoiSetDisplayColor(bool value) {
+	char outputBuff[7] = {0xFE,0x01,0x05,0x00,0x00,0x00,0x00};
+	outputBuff[3] = (uint8_t) value;
+	return Write(outputBuff);
+}
+
 int AsteroidOS::LCD_Tools::Write(char* data) {
 	QFile multiSensorFile("/dev/MultiSensors_CD_01");
 	if(!multiSensorFile.open(QIODevice::WriteOnly | QIODevice::Text))

--- a/src/koi-tools.cpp
+++ b/src/koi-tools.cpp
@@ -31,6 +31,11 @@ int AsteroidOS::LCD_Tools::KoiSetDisplayColor(bool value) {
 	return Write(outputBuff);
 }
 
+int AsteroidOS::LCD_Tools::KoiPrepareTimepiece() {
+	char outputBuff[7] = {0x02,0xC1,0xBE,0x78,0x3F,0x91,0xC7};
+	return Write(outputBuff);
+}
+
 int AsteroidOS::LCD_Tools::Write(char* data) {
 	QFile multiSensorFile("/dev/MultiSensors_CD_01");
 	if(!multiSensorFile.open(QIODevice::WriteOnly | QIODevice::Text))

--- a/src/koi-tools.cpp
+++ b/src/koi-tools.cpp
@@ -37,7 +37,7 @@ void SyncTime(int) {
 	(uint8_t) 0,
 	(uint8_t) ((((dateNow.year() - 2000) & 0xEF) << 1) | ((dateNow.month() & 0x08) >> 3)),
 	(uint8_t) ((dateNow.month() << 5) | (dateNow.day() & 0x1F)),
-	(uint8_t) ((dateNow.dayOfWeek() << 5) | (timeNow.hour() & 0x1F)),
+	(uint8_t) (((dateNow.dayOfWeek() % 7) << 5) | (timeNow.hour() & 0x1F)), //weeks are counted from sunday, sunday encoded as zero.
 	(uint8_t) (timeNow.minute() & 0xFF),
 	(uint8_t) ((timeNow.second() + 1) & 0xFF) //the original casio code seems to add one second here to compensate for an update delay in the subcpu
 	});

--- a/src/koi-tools.h
+++ b/src/koi-tools.h
@@ -1,10 +1,9 @@
 #ifndef ASTEROIDOS_KOI_TOOLS_H
 #define ASTEROIDOS_KOI_TOOLS_H
 
-namespace AsteroidOS::LCD_Tools {
-	int KoiSyncTime();
-	int KoiSetDisplayColor(bool value);
-	int KoiPrepareTimepiece();
-	int Write(char* data);
+namespace AsteroidOS::LCD_Tools::Koi {
+	void SyncTime(int);
+	void SetDisplayColor(bool value);
+	void PrepareTimepiece(int);
 }
 #endif //ASTEROIDOS_KOI_TOOLS_H

--- a/src/koi-tools.h
+++ b/src/koi-tools.h
@@ -4,6 +4,7 @@
 namespace AsteroidOS::LCD_Tools {
 	int KoiSyncTime();
 	int KoiSetDisplayColor(bool value);
+	int KoiPrepareTimepiece();
 	int Write(char* data);
 }
 #endif //ASTEROIDOS_KOI_TOOLS_H

--- a/src/koi-tools.h
+++ b/src/koi-tools.h
@@ -3,6 +3,7 @@
 
 namespace AsteroidOS::LCD_Tools {
 	int KoiSyncTime();
+	int KoiSetDisplayColor(bool value);
 	int Write(char* data);
 }
 #endif //ASTEROIDOS_KOI_TOOLS_H

--- a/src/koi-tools.h
+++ b/src/koi-tools.h
@@ -1,0 +1,8 @@
+#ifndef ASTEROIDOS_KOI_TOOLS_H
+#define ASTEROIDOS_KOI_TOOLS_H
+
+namespace AsteroidOS::LCD_Tools {
+	int KoiSyncTime();
+	int Write(char* data);
+}
+#endif //ASTEROIDOS_KOI_TOOLS_H

--- a/src/lcd-tools.cpp
+++ b/src/lcd-tools.cpp
@@ -11,10 +11,12 @@ int main( int argc, char** argv ) {
 	bool machineCatfish = false;
 	bool machineKoi = false;
 	bool syncTime = false;
+	int koiDisplayColor = -1;
 
 	app.add_flag("--catfish",machineCatfish,"Ticwatch Pro mode");
 	app.add_flag("--koi",machineKoi,"Casio WSD-F10/20 mode");
 	app.add_flag("--sync-time",syncTime,"Sync lcd time with linux time");
+	app.add_option("--set-display",koiDisplayColor,"(Koi) set display color");
 
 	try{
 		app.parse(argc,argv);
@@ -25,6 +27,9 @@ int main( int argc, char** argv ) {
 		} else if (machineKoi) {
 			if (syncTime) {
 				KoiSyncTime();
+			}
+			if (koiDisplayColor != -1) {
+				KoiSetDisplayColor(koiDisplayColor);
 			}
 		} else
 			throw CLI::CallForAllHelp();

--- a/src/lcd-tools.cpp
+++ b/src/lcd-tools.cpp
@@ -10,13 +10,17 @@ int main( int argc, char** argv ) {
 
 	bool machineCatfish = false;
 	bool machineKoi = false;
+
 	bool syncTime = false;
+
 	int koiDisplayColor = -1;
+	bool koiTimepiece = 0;
 
 	app.add_flag("--catfish",machineCatfish,"Ticwatch Pro mode");
 	app.add_flag("--koi",machineKoi,"Casio WSD-F10/20 mode");
 	app.add_flag("--sync-time",syncTime,"Sync lcd time with linux time");
 	app.add_option("--set-display",koiDisplayColor,"(Koi) set display color");
+	app.add_flag("--prepare-timepiece",koiTimepiece,"(Koi) prepare watch for power off into timekeeping mode. You will then need to shut it down manually");
 
 	try{
 		app.parse(argc,argv);
@@ -30,6 +34,9 @@ int main( int argc, char** argv ) {
 			}
 			if (koiDisplayColor != -1) {
 				KoiSetDisplayColor(koiDisplayColor);
+			}
+			if (koiTimepiece) {
+				KoiPrepareTimepiece();
 			}
 		} else
 			throw CLI::CallForAllHelp();

--- a/src/lcd-tools.cpp
+++ b/src/lcd-tools.cpp
@@ -7,7 +7,6 @@
 
 const char* CONFIG_FILE = "/etc/asteroid/machine.conf";
 
-using namespace AsteroidOS::LCD_Tools;
 
 int main( int argc, char** argv ) {
 
@@ -15,41 +14,18 @@ int main( int argc, char** argv ) {
 	const QString machineCodename = m_settings.value("Identity/MACHINE", "unknown").toString();
 
 	CLI::App app{"lcd-tools: Various controls for watches with a secondary displays"};
-
-	bool syncTime = false;
-
-	int koiDisplayColor = -1;
-	bool koiTimepiece = false;
-
-	app.add_flag("--sync-time",syncTime,"Sync lcd time with linux time");
-
 	if (machineCodename == "koi") {
-		app.add_option("--set-display",koiDisplayColor,"(Koi) set display color");
-		app.add_flag("--prepare-timepiece",koiTimepiece,"(Koi) prepare watch for power off into timekeeping mode. You will then need to shut it down manually");
+		using namespace AsteroidOS::LCD_Tools::Koi;
+		app.add_flag("--sync-time",SyncTime,"Sync lcd time with linux time");
+		app.add_flag("--white-background",[](int){SetDisplayColor(true);},"(Koi) set display background to white");
+		app.add_flag("--black-background",[](int){SetDisplayColor(false);},"(Koi) set display background to black");
+		app.add_flag("--prepare-timepiece",PrepareTimepiece,"(Koi) prepare watch for power off into timekeeping mode. You will then need to shut it down manually");
+	} 
+	else if (machineCodename == "catfish") {
+		using namespace AsteroidOS::LCD_Tools::Catfish;
+		app.add_flag("--sync-time",SyncTime,"Sync lcd time with linux time");
 	}
 
-	try{
-		app.parse(argc,argv);
-		if (argc >= 2) {
-			if (machineCodename == "catfish") {
-				if (syncTime) {
-					CatfishSyncTime();
-				}
-			} else if (machineCodename == "koi") {
-				if (syncTime) {
-					KoiSyncTime();
-				}
-				if (koiDisplayColor != -1) {
-					KoiSetDisplayColor(koiDisplayColor);
-				}
-				if (koiTimepiece) {
-					KoiPrepareTimepiece();
-				}
-			}
-		} else
-			throw CLI::CallForAllHelp();
-	} catch (const CLI::ParseError &e){
-		return app.exit(e);
-	}
+	CLI11_PARSE(app, argc, argv);
 	return 0;
 }

--- a/src/lcd-tools.cpp
+++ b/src/lcd-tools.cpp
@@ -1,17 +1,32 @@
-#include "lcd-tools.h"
+#include "catfish-tools.h"
+#include "koi-tools.h"
 
 #include <CLI/CLI.hpp>
 
 using namespace AsteroidOS::LCD_Tools;
 
 int main( int argc, char** argv ) {
-	CLI::App app{"lcd-tools: Various controls for the TicWatch LCD"};
+	CLI::App app{"lcd-tools: Various controls for watches with a secondary displays"};
 
-	app.add_flag_callback("--sync-time",SyncTime,"Sync lcd time with linux time");
+	bool machineCatfish = false;
+	bool machineKoi = false;
+	bool syncTime = false;
+
+	app.add_flag("--catfish",machineCatfish,"Ticwatch Pro mode");
+	app.add_flag("--koi",machineKoi,"Casio WSD-F10/20 mode");
+	app.add_flag("--sync-time",syncTime,"Sync lcd time with linux time");
 
 	try{
 		app.parse(argc,argv);
-		if (argc <= 1)
+		if (machineCatfish) {
+			if (syncTime) {
+				CatfishSyncTime();
+			}
+		} else if (machineKoi) {
+			if (syncTime) {
+				KoiSyncTime();
+			}
+		} else
 			throw CLI::CallForAllHelp();
 	} catch (const CLI::ParseError &e){
 		return app.exit(e);

--- a/src/lcd-tools.cpp
+++ b/src/lcd-tools.cpp
@@ -3,40 +3,48 @@
 
 #include <CLI/CLI.hpp>
 
+#include <QSettings>
+
+const char* CONFIG_FILE = "/etc/asteroid/machine.conf";
+
 using namespace AsteroidOS::LCD_Tools;
 
 int main( int argc, char** argv ) {
-	CLI::App app{"lcd-tools: Various controls for watches with a secondary displays"};
 
-	bool machineCatfish = false;
-	bool machineKoi = false;
+	QSettings m_settings(CONFIG_FILE, QSettings::IniFormat);
+	const QString machineCodename = m_settings.value("Identity/MACHINE", "unknown").toString();
+
+	CLI::App app{"lcd-tools: Various controls for watches with a secondary displays"};
 
 	bool syncTime = false;
 
 	int koiDisplayColor = -1;
-	bool koiTimepiece = 0;
+	bool koiTimepiece = false;
 
-	app.add_flag("--catfish",machineCatfish,"Ticwatch Pro mode");
-	app.add_flag("--koi",machineKoi,"Casio WSD-F10/20 mode");
 	app.add_flag("--sync-time",syncTime,"Sync lcd time with linux time");
-	app.add_option("--set-display",koiDisplayColor,"(Koi) set display color");
-	app.add_flag("--prepare-timepiece",koiTimepiece,"(Koi) prepare watch for power off into timekeeping mode. You will then need to shut it down manually");
+
+	if (machineCodename == "koi") {
+		app.add_option("--set-display",koiDisplayColor,"(Koi) set display color");
+		app.add_flag("--prepare-timepiece",koiTimepiece,"(Koi) prepare watch for power off into timekeeping mode. You will then need to shut it down manually");
+	}
 
 	try{
 		app.parse(argc,argv);
-		if (machineCatfish) {
-			if (syncTime) {
-				CatfishSyncTime();
-			}
-		} else if (machineKoi) {
-			if (syncTime) {
-				KoiSyncTime();
-			}
-			if (koiDisplayColor != -1) {
-				KoiSetDisplayColor(koiDisplayColor);
-			}
-			if (koiTimepiece) {
-				KoiPrepareTimepiece();
+		if (argc >= 2) {
+			if (machineCodename == "catfish") {
+				if (syncTime) {
+					CatfishSyncTime();
+				}
+			} else if (machineCodename == "koi") {
+				if (syncTime) {
+					KoiSyncTime();
+				}
+				if (koiDisplayColor != -1) {
+					KoiSetDisplayColor(koiDisplayColor);
+				}
+				if (koiTimepiece) {
+					KoiPrepareTimepiece();
+				}
 			}
 		} else
 			throw CLI::CallForAllHelp();

--- a/src/lcd-tools.h
+++ b/src/lcd-tools.h
@@ -1,7 +1,0 @@
-#ifndef ASTEROIDOS_LCD_TOOLS_H
-#define ASTEROIDOS_LCD_TOOLS_H
-
-namespace AsteroidOS::LCD_Tools {
-	int SyncTime();
-}
-#endif //ASTEROIDOS_LCD_TOOLS_H


### PR DESCRIPTION
This slightly rearchitects the tool to add support for several watches. Most of the catfish code is completely untouched, but significant crude changes were made to the command line parser. The command line parsing could probably be done more correctly, but I need to get a better understanding of cli11 first. 

The main issue is that this completely messes up the systemd files. I have no idea how to set the systemd files correctly so that the correct commands for the watch are executed. Maybe the machine should be set at compile time instead of as a command line argument? I'd really appreciate some help with this one. 

The final disclaimer is that this is for an unstable device that hasn't been merged yet. 