### PR TITLE
Add support for medaka.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(lcd-tools lcd-tools.cpp catfish-tools.cpp koi-tools.cpp)
+add_executable(lcd-tools lcd-tools.cpp catfish-tools.cpp koi-tools.cpp medaka-tools.cpp)
 target_link_libraries(lcd-tools PUBLIC CLI11::CLI11 Mlite5::Mlite5 Qt::Core ${LIBHYBRIS_LIBRARIES})

--- a/src/koi-tools.cpp
+++ b/src/koi-tools.cpp
@@ -2,7 +2,6 @@
 
 #include <array>
 #include <iostream>
-#include <dlfcn.h>
 #include <MGConfItem>
 
 #include <QTime>

--- a/src/lcd-tools.cpp
+++ b/src/lcd-tools.cpp
@@ -1,5 +1,6 @@
 #include "catfish-tools.h"
 #include "koi-tools.h"
+#include "medaka-tools.h"
 
 #include <CLI/CLI.hpp>
 
@@ -19,6 +20,13 @@ int main( int argc, char** argv ) {
 		app.add_flag("--white-background",[](int){SetDisplayColor(true);},"(Koi) set display background to white");
 		app.add_flag("--black-background",[](int){SetDisplayColor(false);},"(Koi) set display background to black");
 		app.add_flag("--prepare-timepiece",PrepareTimepiece,"(Koi) prepare watch for power off into timekeeping mode. You will then need to shut it down manually");
+		CLI11_PARSE(app, argc, argv);
+	}
+	if (machineCodename == "medaka") {
+		using namespace AsteroidOS::LCD_Tools::Medaka;
+		app.add_flag("--sync-time",SyncTime,"Sync lcd time with linux time");
+		app.add_flag("--white-background",[](int){SetDisplayColor(true);},"(Medaka) set display background to white");
+		app.add_flag("--black-background",[](int){SetDisplayColor(false);},"(Medaka) set display background to black");
 		CLI11_PARSE(app, argc, argv);
 	}
 	else if (machineCodename == "catfish") {

--- a/src/medaka-tools.cpp
+++ b/src/medaka-tools.cpp
@@ -1,0 +1,48 @@
+#include "medaka-tools.h"
+
+#include <array>
+#include <iostream>
+#include <MGConfItem>
+
+#include <QTime>
+#include <QDate>
+#include <QFile>
+
+using SpiMsg = std::array<uint8_t, 7>;
+
+static void Write(const SpiMsg& data) {
+	QFile multiSensorFile("/dev/MultiSensors_CD_01");
+	if(!multiSensorFile.open(QIODevice::WriteOnly | QIODevice::Text))
+	{
+		qCritical("Unable to open file for write. Check permissions");
+		return;
+	}
+	multiSensorFile.write((const char *)data.data(), data.size());
+	multiSensorFile.close();
+}
+
+static void MedakaSet12H(bool value) {
+	Write({0xFE,0x01,0x01,value,0x00,0x00,0x00});
+}
+
+namespace AsteroidOS::LCD_Tools::Medaka {
+
+void SyncTime(int) {
+	MedakaSet12H(!MGConfItem("/org/asteroidos/settings/use-12h-format").value().toBool());
+	QDate dateNow = QDate::currentDate();
+	QTime timeNow = QTime::currentTime();
+	Write({
+	(uint8_t) 0x50,
+	(uint8_t) 0,
+	(uint8_t) ((((dateNow.year() - 2000) & 0xEF) << 1) | ((dateNow.month() & 0x08) >> 3)),
+	(uint8_t) ((dateNow.month() << 5) | (dateNow.day() & 0x1F)),
+	(uint8_t) (((dateNow.dayOfWeek() % 7) << 5) | (timeNow.hour() & 0x1F)), //weeks are counted from sunday, sunday encoded as zero.
+	(uint8_t) (timeNow.minute() & 0xFF),
+	(uint8_t) ((timeNow.second()) & 0xFF)
+	});
+}
+
+void SetDisplayColor(bool value) {
+	Write({0xFE,0x01,0x05,(value ? 0x01 : 0x02),0x00,0x00,0x00});
+}
+} // end of namespace AsteroidOS::LCD_Tools::Medaka

--- a/src/medaka-tools.h
+++ b/src/medaka-tools.h
@@ -1,0 +1,8 @@
+#ifndef ASTEROIDOS_MEDAKA_TOOLS_H
+#define ASTEROIDOS_MEDAKA_TOOLS_H
+
+namespace AsteroidOS::LCD_Tools::Medaka {
+	void SyncTime(int);
+	void SetDisplayColor(bool value);
+}
+#endif //ASTEROIDOS_MEDAKA_TOOLS_H


### PR DESCRIPTION
This adds LCD code for medaka, the WSD-F21HR, successor to koi/ayu. 
The time sync code is identical to koi.
The display colour code uses a different set of bits to encode black vs. white. 
The 'timepiece mode' command is still 'coming soon'. It is quite different, as it needs to select whether it wants to show the date/barometer and battery/step/altimeter data on the top and bottom displays.

The watch isn't actually supported by asteroid yet, but I'm working on cleaning up the port and hopefully that will be added soon. 