### PR TITLE
Add a method for settings to persist using dconf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,5 +14,5 @@ pkg_check_modules(LIBHYBRIS REQUIRED hybris-egl-platform libandroid-properties)
 add_subdirectory(src)
 
 install(TARGETS lcd-tools DESTINATION bin)
-install(FILES systemd/lcd-sync-time.service systemd/lcd-sync-time.timer
+install(FILES systemd/lcd-sync-time.service systemd/lcd-sync-time.timer systemd/lcd-session-restart.service
 		DESTINATION /usr/lib/systemd/user)

--- a/src/koi-tools.cpp
+++ b/src/koi-tools.cpp
@@ -42,8 +42,15 @@ void SyncTime(int) {
 	});
 }
 
-void SetDisplayColor(bool value) {
+void SetDisplayColor(bool value, bool persist) {
+	if (persist) {
+		MGConfItem("/org/asteroidos/lcd-tools/koi/display-color").set(value);
+	}
 	Write({0xFE,0x01,0x05,value,0x00,0x00,0x00});
+}
+
+void SyncSettings(int) {
+	SetDisplayColor(MGConfItem("/org/asteroidos/lcd-tools/medaka/display-color").value().toInt(),false);
 }
 
 void PrepareTimepiece(int) {

--- a/src/koi-tools.h
+++ b/src/koi-tools.h
@@ -3,7 +3,8 @@
 
 namespace AsteroidOS::LCD_Tools::Koi {
 	void SyncTime(int);
-	void SetDisplayColor(bool value);
+	void SyncSettings(int);
+	void SetDisplayColor(bool value, bool persist = true);
 	void PrepareTimepiece(int);
 }
 #endif //ASTEROIDOS_KOI_TOOLS_H

--- a/src/lcd-tools.cpp
+++ b/src/lcd-tools.cpp
@@ -20,6 +20,7 @@ int main( int argc, char** argv ) {
 		app.add_flag("--white-background",[](int){SetDisplayColor(true);},"(Koi) set display background to white");
 		app.add_flag("--black-background",[](int){SetDisplayColor(false);},"(Koi) set display background to black");
 		app.add_flag("--prepare-timepiece",PrepareTimepiece,"(Koi) prepare watch for power off into timekeeping mode. You will then need to shut it down manually");
+		app.add_flag("--session-restart",SyncSettings,"Initialise LCD for user session restart");
 		CLI11_PARSE(app, argc, argv);
 	}
 	if (machineCodename == "medaka") {
@@ -27,6 +28,7 @@ int main( int argc, char** argv ) {
 		app.add_flag("--sync-time",SyncTime,"Sync lcd time with linux time");
 		app.add_flag("--white-background",[](int){SetDisplayColor(true);},"(Medaka) set display background to white");
 		app.add_flag("--black-background",[](int){SetDisplayColor(false);},"(Medaka) set display background to black");
+		app.add_flag("--session-restart",SyncSettings,"Initialise LCD for user session restart");
 		CLI11_PARSE(app, argc, argv);
 	}
 	else if (machineCodename == "catfish") {
@@ -39,6 +41,7 @@ int main( int argc, char** argv ) {
 		app.add_flag("--disable-heartrate",[&catfish](int){ catfish.DisableHeartRate(); },"(Catfish) Disable the heart rate sensor");
 		app.add_flag("--enable-motion",[&catfish](int){ catfish.EnableMotion(); },"(Catfish) Enable motion");
 		app.add_flag("--disable-motion",[&catfish](int){ catfish.DisableMotion(); },"(Catfish) Disable motion");
+		app.add_flag("--session-restart","Initialise LCD for user session restart"); // this isn't used on catfish, but the service to error out if this option isn't present.
 		CLI11_PARSE(app, argc, argv);
 	}
 

--- a/src/medaka-tools.cpp
+++ b/src/medaka-tools.cpp
@@ -42,7 +42,14 @@ void SyncTime(int) {
 	});
 }
 
-void SetDisplayColor(bool value) {
+void SyncSettings(int) { // this is meant to be run on a session restart
+	SetDisplayColor(MGConfItem("/org/asteroidos/lcd-tools/medaka/display-color").value().toInt(),false);
+}
+
+void SetDisplayColor(bool value, bool persist) {
+	if (persist) {
+		MGConfItem("/org/asteroidos/lcd-tools/medaka/display-color").set(value);
+	}
 	Write({0xFE,0x01,0x05,(value ? 0x01 : 0x02),0x00,0x00,0x00});
 }
 } // end of namespace AsteroidOS::LCD_Tools::Medaka

--- a/src/medaka-tools.h
+++ b/src/medaka-tools.h
@@ -3,6 +3,7 @@
 
 namespace AsteroidOS::LCD_Tools::Medaka {
 	void SyncTime(int);
-	void SetDisplayColor(bool value);
+	void SyncSettings(int);
+	void SetDisplayColor(bool value, bool persist = true);
 }
 #endif //ASTEROIDOS_MEDAKA_TOOLS_H

--- a/systemd/lcd-session-restart.service
+++ b/systemd/lcd-session-restart.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Sync user's LCD settings
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/lcd-tools --session-restart
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This currently only affects koi and medaka, as I'm only familiar with how the subcpu works on those. Settings (currently only the LCD colour mode on medaka and koi) are going to be persisted across reboots. The settings are restored by running `lcd-tools --session-restart` as a systemd service
there's a corresponding PR on https://github.com/asteroidos/meta-asteroid

This implementation does work, but I'm not sure if it's exactly how we want this to work. I hope this at least serves as a good basis for discussion.