### PR TITLE
Fix wrong reference to medaka instead of koi

### DIFF
--- a/src/koi-tools.cpp
+++ b/src/koi-tools.cpp
@@ -50,7 +50,7 @@ void SetDisplayColor(bool value, bool persist) {
 }
 
 void SyncSettings(int) {
-	SetDisplayColor(MGConfItem("/org/asteroidos/lcd-tools/medaka/display-color").value().toInt(),false);
+	SetDisplayColor(MGConfItem("/org/asteroidos/lcd-tools/koi/display-color").value().toInt(),false);
 }
 
 void PrepareTimepiece(int) {


### PR DESCRIPTION
This accidentally slipped through two reviews :shrug: 