### PR TITLE
Add support for rubyfish (TicWatch Pro 3)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(lcd-tools lcd-tools.cpp catfish-tools.cpp koi-tools.cpp medaka-tools.cpp)
+add_executable(lcd-tools lcd-tools.cpp catfish-tools.cpp rubyfish-tools.cpp koi-tools.cpp medaka-tools.cpp)
 target_link_libraries(lcd-tools PUBLIC CLI11::CLI11 Mlite5::Mlite5 Qt::Core ${LIBHYBRIS_LIBRARIES})

--- a/src/lcd-tools.cpp
+++ b/src/lcd-tools.cpp
@@ -1,4 +1,5 @@
 #include "catfish-tools.h"
+#include "rubyfish-tools.h"
 #include "koi-tools.h"
 #include "medaka-tools.h"
 
@@ -42,6 +43,19 @@ int main( int argc, char** argv ) {
 		app.add_flag("--enable-motion",[&catfish](int){ catfish.EnableMotion(); },"(Catfish) Enable motion");
 		app.add_flag("--disable-motion",[&catfish](int){ catfish.DisableMotion(); },"(Catfish) Disable motion");
 		app.add_flag("--session-restart","Initialise LCD for user session restart"); // this isn't used on catfish, but the service to error out if this option isn't present.
+		CLI11_PARSE(app, argc, argv);
+	}
+	else if (machineCodename ==  "rubyfish") {
+		RubyfishLcdTools rubyfish;
+		app.add_flag("--sync-time",[&rubyfish](int){ rubyfish.SyncTime(); },"Sync lcd time with linux time");
+		app.add_flag("--prepare-timepiece",[&rubyfish](int){ rubyfish.PrepareTimepiece(); },"(rubyfish) Start timepiece only mode");
+		app.add_flag("--enable-stepcounter",[&rubyfish](int){ rubyfish.EnableStepCounter(); },"(rubyfish) Enable the step counter");
+		app.add_flag("--disable-stepcounter",[&rubyfish](int){ rubyfish.DisableStepCounter(); },"(rubyfish) Disable the step counter");
+		app.add_flag("--enable-heartrate",[&rubyfish](int){ rubyfish.EnableHeartRate(); },"(rubyfish) Enable the heart rate sensor");
+		app.add_flag("--disable-heartrate",[&rubyfish](int){ rubyfish.DisableHeartRate(); },"(rubyfish) Disable the heart rate sensor");
+		app.add_flag("--enable-motion",[&rubyfish](int){ rubyfish.EnableMotion(); },"(rubyfish) Enable motion");
+		app.add_flag("--disable-motion",[&rubyfish](int){ rubyfish.DisableMotion(); },"(rubyfish) Disable motion");
+		app.add_flag("--session-restart","Initialise LCD for user session restart"); // this isn't used on rubyfish, but the service to error out if this option isn't present.
 		CLI11_PARSE(app, argc, argv);
 	}
 

--- a/src/rubyfish-tools.cpp
+++ b/src/rubyfish-tools.cpp
@@ -1,0 +1,125 @@
+#include "rubyfish-tools.h"
+
+#include <iostream>
+#include <dlfcn.h>
+#include <hybris/common/dlfcn.h>
+#include <hybris/properties/properties.h>
+#include <MGConfItem>
+
+RubyfishLcdTools::RubyfishLcdTools() {
+	mcutool_handle = OpenLibrary();
+	LoadSymbols();
+}
+RubyfishLcdTools::~RubyfishLcdTools() {
+	CloseLibrary(mcutool_handle);
+}
+
+void* RubyfishLcdTools::OpenLibrary() {
+	auto lib_mcutool = hybris_dlopen("libmcutool.so", RTLD_LAZY);
+	if (!lib_mcutool) {
+		std::cerr << "Unable to load libmcutool.so" << std::endl;
+		return nullptr;
+	}
+	return lib_mcutool;
+}
+
+void* RubyfishLcdTools::LoadSymbol(const char *symbol_string) {
+	void *symbol = hybris_dlsym(mcutool_handle, symbol_string);
+	if (!symbol) {
+		std::cerr << "Unable to get symbol " << symbol_string << std::endl;
+		return nullptr;
+	}
+	return symbol;
+}
+
+void RubyfishLcdTools::LoadSymbols() {
+	if (!mcutool_handle) return;
+
+	nativeFunctions.autoLowPowerScreen = (int (*)(int32_t, int32_t, int32_t)) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeAutoLowPowerScreen");
+	nativeFunctions.bandMode = (int (*)()) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeBandMode");
+	nativeFunctions.cutOffScreen = (int (*)()) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeCutOffScreen");
+	nativeFunctions.enableHeartRate = (int (*)(int32_t, int32_t, int32_t)) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeEnableHeartRate");
+	nativeFunctions.enableLowPowerScreen = (int (*)(int32_t, int32_t, int32_t)) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeEnableLowPowerScreen");
+	nativeFunctions.enableMotion = (int (*)(int32_t, int32_t, int32_t)) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeEnableMotion");
+	nativeFunctions.enableStepCounter = (int (*)(int32_t, int32_t, int32_t)) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeEnableStepCounter");
+	nativeFunctions.getBandModeData = (int (*)()) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeGetBandModeData");
+	nativeFunctions.getDataVersion = (int (*)()) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeGetDataVersion");
+	nativeFunctions.syncSteps = (int (*)(int32_t, int32_t, int32_t)) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeSyncSteps");
+	nativeFunctions.syncTime = (int (*)()) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeSyncTime");
+	nativeFunctions.updateFitnessState = (int (*)(int32_t, int32_t, int32_t, int32_t, int32_t, int64_t, int32_t, float, int32_t, int32_t, uint8_t)) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeUpdateFitnessState");
+	nativeFunctions.wipeBandModeData = (int (*)()) LoadSymbol("Java_com_mobvoi_ticwear_mcuservice_backend_CoreService_nativeWipeBandModeData");
+}
+
+int RubyfishLcdTools::CloseLibrary(void* lib_mcutool) {
+	if (hybris_dlclose(lib_mcutool)) {
+		std::cerr << "Failed to safely close the library" << std::endl;
+		return -1;
+	}
+	return 0;
+}
+
+int RubyfishLcdTools::SyncTime() {
+	auto use12h = new MGConfItem("/org/asteroidos/settings/use-12h-format");
+
+	if (use12h->value(false).toBool()) {
+		property_set("persist.sys.time_12_24", "12");
+	} else {
+		property_set("persist.sys.time_12_24", "24");
+	}
+
+	return nativeFunctions.syncTime();
+}
+
+int RubyfishLcdTools::PrepareTimepiece() {
+	int res;
+	res = nativeFunctions.autoLowPowerScreen(0, 0, true);
+	if (res) {
+		std::cerr << "ERROR autoLowPowerScreen: " << res << std::endl;
+	}
+	// res = nativeEnableLowPowerScreen(0, 0, true);
+	// if (res) {
+	// 	std::cerr << "ERROR nativeEnableLowPowerScreen: " << res << std::endl;
+	// }
+	res = nativeFunctions.autoLowPowerScreen(0, 0, false);
+	if (res) {
+		std::cerr << "ERROR autoLowPowerScreen: " << res << std::endl;
+	}
+	res = nativeFunctions.cutOffScreen();
+	if (res) {
+		std::cerr << "ERROR cutOffScreen: " << res << std::endl;
+	}
+	res = nativeFunctions.wipeBandModeData();
+	if (res) {
+		std::cerr << "ERROR wipeBandModeData: " << res << std::endl;
+	}
+	res = nativeFunctions.bandMode();
+	if (res) {
+		std::cerr << "ERROR bandMode: " << res << std::endl;
+	}
+	return 1;
+}
+
+int RubyfishLcdTools::DisableStepCounter() {
+	return nativeFunctions.enableStepCounter(0, 0, false);
+}
+
+int RubyfishLcdTools::EnableStepCounter() {
+	return nativeFunctions.enableStepCounter(0, 0, true);
+}
+
+int RubyfishLcdTools::DisableHeartRate() {
+	return nativeFunctions.enableHeartRate(0, 0, false);
+}
+
+int RubyfishLcdTools::EnableHeartRate() {
+	return nativeFunctions.enableHeartRate(0, 0, true);
+}
+
+int RubyfishLcdTools::DisableMotion() {
+	return nativeFunctions.enableMotion(0, 0, false);
+}
+
+int RubyfishLcdTools::EnableMotion() {
+	return nativeFunctions.enableMotion(0, 0, true);
+}
+

--- a/src/rubyfish-tools.h
+++ b/src/rubyfish-tools.h
@@ -1,0 +1,44 @@
+#ifndef ASTEROIDOS_RUBYFISH_TOOLS_H
+#define ASTEROIDOS_RUBYFISH_TOOLS_H
+
+#include <cstdint>
+
+class RubyfishLcdTools {
+public:
+	RubyfishLcdTools();
+	virtual ~RubyfishLcdTools();
+	virtual int SyncTime();
+	virtual int PrepareTimepiece();
+	virtual int DisableStepCounter();
+	virtual int EnableStepCounter();
+	virtual int DisableHeartRate();
+	virtual int EnableHeartRate();
+	virtual int DisableMotion();
+	virtual int EnableMotion();
+private:
+	void* OpenLibrary();
+	void LoadSymbols();
+	void* LoadSymbol(const char *symbol_string);
+	int CloseLibrary(void* lib_mcutool);
+	void* mcutool_handle;
+
+	typedef struct nativeFunctions_t {
+		int (*autoLowPowerScreen)(int32_t, int32_t, int32_t enable);
+		int (*bandMode)();
+		int (*cutOffScreen)();
+		int (*enableHeartRate)(int32_t, int32_t, int32_t enable);
+		int (*enableLowPowerScreen)(int32_t, int32_t, int32_t enable);
+		int (*enableMotion)(int32_t, int32_t, int32_t enable);
+		int (*enableStepCounter)(int32_t, int32_t, int32_t enable);
+		int (*getBandModeData)();
+		int (*getDataVersion)();
+		int (*syncSteps)(int32_t, int32_t, int32_t steps);
+		int (*syncTime)();
+		int (*updateFitnessState)(int32_t, int32_t, int32_t type, int32_t state, int32_t heartRate, int64_t duration, int32_t calorie, float distance, int32_t speed, int32_t gpsStatus, uint8_t isKilometer);
+		int (*wipeBandModeData)();
+	} nativeFunctions_t;
+
+	nativeFunctions_t nativeFunctions;
+};
+
+#endif //ASTEROIDOS_RUBYFISH_TOOLS_H


### PR DESCRIPTION
This is basically a one-to-one copy of catfish with only one exception.
It turns out that the manufacturer has changed the exposed function names.

Only the time synchronization functionality has been tested.